### PR TITLE
Pin dev dependencies to their exact version and group them in dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: monthly
   - package-ecosystem: cargo
     directory: /
+    groups:
+      dev-dependencies:
+        dependency-type: development
     schedule:
       interval: monthly
   - package-ecosystem: devcontainers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,9 +595,9 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "codspeed"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a104ac948e0188b921eb3fcbdd55dcf62e542df4c7ab7e660623f6288302089"
+checksum = "b0c6f324a032703f286b0fbbdb390971f914b41f3410e1615c59730e4b24ebc2"
 dependencies = [
  "colored",
  "libc",
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-criterion-compat"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722c36bdc62d9436d027256ce2627af81ac7a596dfc7d13d849d0d212448d7fe"
+checksum = "0ae52f6f2545ffcd2ac1308f34043eb6ab81e4c741af419b348b2325574f48ee"
 dependencies = [
  "codspeed",
  "colored",
@@ -2668,9 +2668,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,15 +40,15 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [dev-dependencies]
-assert_cmd = "2.0.16"
-codspeed-criterion-compat = "2.4.1"
-criterion = "0.5.1"
-httpmock = "0.7.0"
-indoc = "2.0.5"
-proptest = "1.4.0"
-rstest = "0.22.0"
-serde_json = "1.0.127"
-tempfile = "3.12.0"
+assert_cmd = "=2.0.16"
+codspeed-criterion-compat = "=2.7.1"
+criterion = "=0.5.1"
+httpmock = "=0.7.0"
+indoc = "=2.0.5"
+proptest = "1.5.0"
+rstest = "=0.22.0"
+serde_json = "=1.0.128"
+tempfile = "=3.12.0"
 
 [features]
 default = ["detect-allowed-signers"]


### PR DESCRIPTION
Pins development dependencies to their exact latest version. Upgrades will be performed monthly by dependabot.