### PR TITLE
Remove allowed signer file option from configuration and no longer merge it with runtime args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,6 +890,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,6 +1350,7 @@ dependencies = [
  "gix-config",
  "httpmock",
  "indoc",
+ "predicates",
  "proptest",
  "reqwest",
  "rstest",
@@ -1891,6 +1901,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2125,13 +2141,16 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [dev-dependencies]
 assert_cmd = "=2.0.16"
+predicates = "=3.1.2"
 codspeed-criterion-compat = "=2.7.2"
 criterion = "=0.5.1"
 httpmock = "=0.7.0"

--- a/benches/load_configuration.rs
+++ b/benches/load_configuration.rs
@@ -25,7 +25,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let path: &Path = &file.into_temp_path();
 
     c.bench_function("load the example configuration", |b| {
-        b.iter(|| Configuration::load_and_validate(path, None).unwrap());
+        b.iter(|| Configuration::load_and_validate(path).unwrap());
     });
 }
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -50,7 +50,7 @@ struct GlobalArgs {
         env = "HANKO_ALLOWED_SIGNERS",
         default_value = git_allowed_signers()
     )]
-    pub file: Option<PathBuf>,
+    pub file: PathBuf,
 
     /// Use verbose output.
     #[arg(short, long, action = clap::ArgAction::Count)]
@@ -105,7 +105,7 @@ pub async fn entrypoint() -> Result<()> {
 
     let config =
         Configuration::load_and_validate(&args.config).context("Failed to load configuration")?;
-    let signers_file = &args.file.as_deref().unwrap();
+    let signers_file = &args.file;
 
     match &cli.command {
         Commands::Update => {

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -10,23 +10,12 @@ use tracing::{debug, info, Level};
 
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
-pub struct Args {
-    /// The configuration file.
-    #[arg(
-        short,
-        long,
-        value_name = "PATH",
-        env = "HANKO_CONFIG",
-        default_value = default_config_path()
-    )]
-    pub config: PathBuf,
-
-    // The runtime configuration.
-    #[command(flatten)]
-    runtime_config: RuntimeConfiguration,
-
+pub struct Cli {
     #[command(subcommand)]
     command: Commands,
+
+    #[command(flatten)]
+    global_args: GlobalArgs,
 }
 
 #[derive(Debug, Subcommand)]
@@ -42,9 +31,18 @@ enum Commands {
     // Source(ManageSources),
 }
 
-/// Runtime configuration that overrides the configuration file.
 #[derive(Debug, Serialize, Deserialize, clap::Args)]
-pub struct RuntimeConfiguration {
+struct GlobalArgs {
+    /// The configuration file.
+    #[arg(
+        short,
+        long,
+        value_name = "PATH",
+        env = "HANKO_CONFIG",
+        default_value = default_config_path()
+    )]
+    pub config: PathBuf,
+
     /// The allowed signers file.
     #[arg(
         long,
@@ -54,7 +52,7 @@ pub struct RuntimeConfiguration {
     )]
     pub file: Option<PathBuf>,
 
-    /// Increase verbosity.
+    /// Use verbose output.
     #[arg(short, long, action = clap::ArgAction::Count)]
     pub verbose: u8,
 }
@@ -100,29 +98,30 @@ fn git_allowed_signers() -> Resettable<OsStr> {
 #[tokio::main]
 pub async fn entrypoint() -> Result<()> {
     let start = Instant::now();
-    let args = Args::parse();
+    let cli = Cli::parse();
+    let args = cli.global_args;
 
-    setup_tracing(args.runtime_config.verbose);
+    setup_tracing(args.verbose);
 
-    let config = Configuration::load_and_validate(&args.config, Some(args.runtime_config))
-        .context("Failed to load configuration")?;
+    let config =
+        Configuration::load_and_validate(&args.config).context("Failed to load configuration")?;
+    let signers_file = &args.file.as_deref().unwrap();
 
-    match &args.command {
+    match &cli.command {
         Commands::Update => {
-            let path = config.allowed_signers_file();
             let sources = config.sources();
             debug!(?sources, "Initialized sources");
             let signers = config.signers(&sources);
             debug!(?signers, "Initialized signers");
 
-            update(path, signers)
+            update(signers_file, signers)
                 .await
                 .context("Failed to update the allowed signers file")?;
 
             let duration = start.elapsed();
             info!(
                 "Updated allowed signers file {} in {:?}",
-                path.display(),
+                signers_file.display(),
                 duration
             );
         }
@@ -162,6 +161,6 @@ mod tests {
     #[test]
     fn verify_cli() {
         use clap::CommandFactory;
-        Args::command().debug_assert();
+        Cli::command().debug_assert();
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,4 @@
-pub use main::{entrypoint, RuntimeConfiguration};
+pub use main::entrypoint;
 
 mod main;
 mod manage_signers;

--- a/tests/update_cmd.rs
+++ b/tests/update_cmd.rs
@@ -2,6 +2,8 @@
 use assert_cmd::Command;
 use httpmock::prelude::*;
 use indoc::{formatdoc, indoc};
+#[cfg(not(feature = "detect-allowed-signers"))]
+use predicates::prelude::*;
 use rstest::*;
 use serde_json::json;
 use std::io::Write;
@@ -148,4 +150,36 @@ fn update_writes_expected_allowed_signers(
     let content = std::fs::read_to_string(allowed_signers.path()).unwrap();
 
     assert_eq!(content, expected_content);
+}
+
+/// When running the update command with the `detect-allowed-signers` feature enabled and
+/// an allowed signers file configured within git, the file argument is not required.
+#[test]
+#[ignore]
+#[cfg(feature = "detect-allowed-signers")]
+fn file_arg_not_required_with_detect_feature_and_git_allowed_signers_config() {
+    todo!()
+}
+
+/// When running the update command with the `detect-allowed-signers` feature enabled but
+/// without an allowed signers file configured within git, the file argument is required.
+#[test]
+#[ignore]
+#[cfg(feature = "detect-allowed-signers")]
+fn file_arg_required_with_detect_feature_but_without_git_allowed_signers_config() {
+    todo!()
+}
+
+/// When running the update command without the `detect-allowed-signers` feature enabled,
+/// the file argument is required.
+#[test]
+#[cfg(not(feature = "detect-allowed-signers"))]
+fn file_arg_required_without_detect_feature() {
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.arg("update")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "error: The following required argument was not provided: file",
+        ));
 }


### PR DESCRIPTION
No longer conflate command line arguments with configuration to allow for saving configuration changes back to file in the future.