### PR TITLE
Ignore RUSTSEC-2025-0021 as it is not applicable

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "**/Cargo.lock"
       - "**/Cargo.toml"
+      - "deny.toml"
   workflow_dispatch:
 
 permissions:

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,9 @@ all-features = true
 version = 2
 db-path = "$CARGO_HOME/advisory-dbs"
 db-urls = ["https://github.com/rustsec/advisory-db"]
+ignore = [
+    "RUSTSEC-2025-0021", # Not applicable
+]
 
 [licenses]
 version = 2


### PR DESCRIPTION
Hanko does not read git objects, only configuration